### PR TITLE
makes recommended change to gemfile lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
     pg (1.4.5)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -188,6 +190,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)


### PR DESCRIPTION
Ran into an error when pushing to Heroku main where the bundle platform didn't match my local platform so I had to add it to the gemfile.lock.