### PR TITLE
Adds search_breweries endpoints to readme and moves faraday gem to ap…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'puma', '~> 3.11'
 gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+gem 'faraday'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -35,7 +36,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'shoulda-matchers'
   gem 'hirb'
-  gem 'faraday'
   gem 'factory_bot_rails'
   gem 'faker'
 end

--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ _For more examples, please refer to the [Documentation](https://example.com)_
     - Headers: 
       - CONTENT_TYPE => application/json
 
+- /search_breweries
+  - Breweries by location
+    - GET search_breweries?location="latitude,longitude"
+      - Returns the nearest breweries to the location entered
+  - Breweries by name
+    - GET search_breweries?name="name_fragment"&count="number_of_results"
+      - Returns breweries in Colorado that closest match the name entered
+  - Brewery by ID
+    - GET search_breweries?id="brewery_id"
+      - Returns the exact match for a brewery with that ID
+
+
 See the [open issues](https://github.com/TrailsNbrews/trails_n_brews_BE/issues) for a full list of proposed features (and known issues).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/app/controllers/api/v1/search_breweries_controller.rb
+++ b/app/controllers/api/v1/search_breweries_controller.rb
@@ -2,7 +2,6 @@ class Api::V1::SearchBreweriesController < ApplicationController
   def index
     location = params[:loc]
     count = params[:count]
-
     brews_by_location = OpenBrewService.find_by_location(location, count)
     render json: BrewerySerializer.location_serializer(brews_by_location)
   end


### PR DESCRIPTION
…ply to all

Adds to readme the search_breweries endpoints

Fix: In the gemfile moved 'faraday' out of development/test so that it is available in production. Right now the Heroku live can't use Faraday to call the brewery API.