### PR TITLE
Edits brewery serializers so that it renders street and not address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'puma', '~> 3.11'
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
+gem 'nokogiri', '~> 1.14', '>= 1.14.2'
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 
@@ -27,6 +27,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 gem 'faraday'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     pg (1.4.5)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -201,6 +203,7 @@ DEPENDENCIES
   faraday
   hirb
   listen (>= 3.0.5, < 3.2)
+  nokogiri (~> 1.14, >= 1.14.2)
   pg
   pry-rails
   puma (~> 3.11)

--- a/app/serializers/brewery_serializer.rb
+++ b/app/serializers/brewery_serializer.rb
@@ -7,7 +7,7 @@ class BrewerySerializer
             "id": brewery[:id],
             "attributes": {
                           "name": brewery[:name],
-                          "address": brewery[:address],
+                          "street": brewery[:street],
                           "city": brewery[:city],
                           "state": brewery[:state],
                           "postal_code": brewery[:postal_code],
@@ -30,7 +30,7 @@ class BrewerySerializer
             "attributes": 
             {
                         "name": brewery[:name],
-                        "address": brewery[:adress],
+                        "street": brewery[:street],
                         "city": brewery[:city],
                         "state": brewery[:state],
                         "postal_code": brewery[:postal_code],

--- a/app/serializers/trail_serializer.rb
+++ b/app/serializers/trail_serializer.rb
@@ -26,7 +26,6 @@ class TrailSerializer
   end
 
   def self.format_trail_with_breweries(trail)
-    # binding.pry
     {
       "data":{"trail": trail_properties(trail[:trail]),
              "breweries": trail[:breweries].map do |brewery|
@@ -35,7 +34,7 @@ class TrailSerializer
                   "id": brewery[:id],
                   "attributes": {
                                 "name": brewery[:name],
-                                "address": brewery[:address],
+                                "street": brewery[:street],
                                 "city": brewery[:city],
                                 "state": brewery[:state],
                                 "postal_code": brewery[:postal_code],

--- a/spec/requests/api/v1/search_breweries_request_spec.rb
+++ b/spec/requests/api/v1/search_breweries_request_spec.rb
@@ -58,7 +58,6 @@ describe 'Search Breweries API' do
         count = 7
         name = 'Odell'
         get "/api/v1/search_breweries?name=#{name}&count=#{count}" 
-      # require 'pry';binding.pry
         expect(response).to be_successful
         expect(response.status).to eq(200)
 

--- a/spec/requests/api/v1/search_trails_spec.rb
+++ b/spec/requests/api/v1/search_trails_spec.rb
@@ -75,7 +75,7 @@ describe 'Search Trails API' do
         expect(brewery[:attributes]).to have_key(:longitude)
         expect(brewery[:attributes]).to have_key(:latitude)
         expect(brewery[:attributes]).to have_key(:website_url)
-        expect(brewery[:attributes]).to have_key(:address)
+        expect(brewery[:attributes]).to have_key(:street)
         expect(brewery[:attributes]).to have_key(:phone)
       end
     end


### PR DESCRIPTION
In the serializers that render breweries
- changed "address":brewery[:address] to "street": brewery[:street]